### PR TITLE
Help n img select bug

### DIFF
--- a/app/src/main/java/com/acash/bechdo/activities/ProfileActivity.kt
+++ b/app/src/main/java/com/acash/bechdo/activities/ProfileActivity.kt
@@ -23,6 +23,7 @@ import com.acash.bechdo.R
 import com.acash.bechdo.models.Colleges
 import com.acash.bechdo.models.User
 import com.acash.bechdo.utils.getCurrentLocale
+import com.bumptech.glide.Glide
 import com.google.android.gms.tasks.Continuation
 import com.google.android.gms.tasks.Task
 import com.google.firebase.auth.FirebaseAuth
@@ -72,7 +73,10 @@ class ProfileActivity : AppCompatActivity() {
                 if (result.resultCode == RESULT_OK) {
                     result.data?.data?.let { uri ->
                         dpUri = uri
-                        image_view.setImageURI(uri)
+
+                        Glide.with(this).load(uri).placeholder(R.drawable.default_avatar)
+                            .error(R.drawable.default_avatar)
+                            .into(image_view)
                     }
                 }
             }

--- a/app/src/main/java/com/acash/bechdo/adapters/ProductPicsPostAdapter.kt
+++ b/app/src/main/java/com/acash/bechdo/adapters/ProductPicsPostAdapter.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.acash.bechdo.R
+import com.bumptech.glide.Glide
 import kotlinx.android.synthetic.main.list_item_product_pic_post.view.*
 
 class ProductPicsPostAdapter(private val pics:ArrayList<Uri>):RecyclerView.Adapter<ProductPicsPostAdapter.ProductPicsHolder>() {
@@ -18,16 +19,22 @@ class ProductPicsPostAdapter(private val pics:ArrayList<Uri>):RecyclerView.Adapt
         ProductPicsHolder(LayoutInflater.from(parent.context).inflate(R.layout.list_item_product_pic_post,parent,false))
 
     override fun onBindViewHolder(holder: ProductPicsHolder, position: Int) {
-        holder.itemView.imgView.setImageURI(null)
-        if(position==0){
-            holder.itemView.apply {
+        holder.itemView.apply {
+            Glide.with(this)
+                .clear(imgView)
+
+            if (position == 0) {
                 cardView.background = ContextCompat.getDrawable(context, R.drawable.add_product_pic)
                 imgView.setBackgroundColor(Color.TRANSPARENT)
                 setOnClickListener {
-                   onClick?.invoke()
+                    onClick?.invoke()
                 }
+            } else if (position < pics.size + 1) {
+                Glide.with(this).load(pics[position - 1])
+                    .error(R.drawable.default_image)
+                    .into(imgView)
             }
-        }else if(position<pics.size+1) holder.itemView.imgView.setImageURI(pics[position-1])
+        }
     }
 
     override fun getItemCount() = 8

--- a/app/src/main/java/com/acash/bechdo/fragments/mainactivity/EditProfileFragment.kt
+++ b/app/src/main/java/com/acash/bechdo/fragments/mainactivity/EditProfileFragment.kt
@@ -61,7 +61,11 @@ class EditProfileFragment : Fragment() {
                 if (result.resultCode == AppCompatActivity.RESULT_OK) {
                     result.data?.data?.let { uri ->
                         newDp = uri
-                        image_view.setImageURI(uri)
+
+                        Glide.with(requireContext()).load(uri).placeholder(R.drawable.default_avatar)
+                            .error(R.drawable.default_avatar)
+                            .into(image_view)
+
                         isNewDpSelected = true
                     }
                 }
@@ -100,7 +104,9 @@ class EditProfileFragment : Fragment() {
         (activity as MainActivity).currentUserInfo?.let { user ->
 
             if(::newDp.isInitialized){
-                image_view.setImageURI(newDp)
+                Glide.with(requireContext()).load(newDp)
+                    .placeholder(R.drawable.default_avatar)
+                    .error(R.drawable.default_avatar).into(image_view)
             }else user.downloadUrlDp.let { url ->
                 if (url != "") {
                     Glide.with(requireContext()).load(url)

--- a/app/src/main/java/com/acash/bechdo/fragments/mainactivity/HelpFragment.kt
+++ b/app/src/main/java/com/acash/bechdo/fragments/mainactivity/HelpFragment.kt
@@ -1,14 +1,14 @@
 package com.acash.bechdo.fragments.mainactivity
 
+import android.content.ActivityNotFoundException
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.acash.bechdo.R
 import com.acash.bechdo.adapters.FaqAdapter
@@ -58,9 +58,9 @@ class HelpFragment : Fragment() {
             intent.data = Uri.parse("mailto:")
             intent.putExtra(Intent.EXTRA_EMAIL,arrayOf("Bechdoofficial@gmail.com"))
 
-            if(requireContext().packageManager.resolveActivity(intent,PackageManager.MATCH_DEFAULT_ONLY)!=null){
+            try{
                 startActivity(intent)
-            }else{
+            }catch (e:ActivityNotFoundException){
                 Toast.makeText(requireContext(),"No suitable apps found for sending Email",Toast.LENGTH_SHORT).show()
             }
         }

--- a/app/src/main/java/com/acash/bechdo/fragments/mainactivity/SellProductsFragment.kt
+++ b/app/src/main/java/com/acash/bechdo/fragments/mainactivity/SellProductsFragment.kt
@@ -22,15 +22,19 @@ class SellProductsFragment : Fragment() {
         val view = inflater.inflate(R.layout.fragment_sell_products, container, false)
 
         Glide.with(requireContext()).load(R.drawable.sell_products_card_bg)
+            .error(R.drawable.default_image)
             .into(view.imgViewSellProducts)
 
         Glide.with(requireContext()).load(R.drawable.rent_products_card_bg)
+            .error(R.drawable.default_image)
             .into(view.imgViewRentProducts)
 
         Glide.with(requireContext()).load(R.drawable.active_products_card_bg)
+            .error(R.drawable.default_image)
             .into(view.imgViewActvProducts)
 
         Glide.with(requireContext()).load(R.drawable.sold_products_card_bg)
+            .error(R.drawable.default_image)
             .into(view.imgViewSoldProducts)
 
         return view


### PR DESCRIPTION
## Description
Previously on clicking Contact us button in Help section, a toast `No suitable apps found for sending Email` was shown in some devices. This happened because from Android 11, the apps installed on the device cannot be fetched from package manager(unless specified explicitly using query tag in the manifest) and resolveActivity returned null. Using try-catch instead of packageManager.resolveActivity() resolved this bug.

Apart from that on selecting larger images while posting a product caused a crash in some devices with an exception `Canvas: trying to draw too large bitmap`. This bug was resolved by using Glide to load the selected images from uri. Observing this behavior, Glide has also been used to load selected image from uri in Profile Activity and Edit Profile Fragment.

## Type of Contribution:

- [x] Bug fix
- [x] Coding
- [ ] Design
- [ ] Testing
- [ ] Research
- [ ] Enhancement
- [ ] Documentation
- [ ] Other 

## Checklist:

- [x] I have read README.md and CONTRIBUTION.md
- [x] My Pull request is made against `develop` branch.
- [x] My code/design follows the style/guidelines of this project.
- [x] I have performed a self-review of my own code/design/documentation.
- [x] I have commented my code, particularly in hard-to-understand areas(or gave a proper description about the design).
